### PR TITLE
CI: test windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:

--- a/pyhocon/compat.py
+++ b/pyhocon/compat.py
@@ -1,0 +1,3 @@
+from sys import platform
+
+is_windows = platform in ["win32", "cygwin"]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -10,6 +10,7 @@ import pytest
 from pyparsing import ParseBaseException, ParseException, ParseSyntaxException
 
 from pyhocon import ConfigFactory, ConfigParser, ConfigSubstitutionException, ConfigTree
+from pyhocon.compat import is_windows
 from pyhocon.exceptions import (
     ConfigException,
     ConfigMissingException,
@@ -1170,6 +1171,7 @@ class TestConfigParser:
         with pytest.raises(ParseSyntaxException):
             ConfigFactory.parse_string("a = {g}")
 
+    @pytest.mark.skipif(is_windows, reason="fails on windows")
     def test_include_file(self):
         with tempfile.NamedTemporaryFile("w") as fdin:
             fdin.write("[1, 2]")
@@ -1291,6 +1293,7 @@ class TestConfigParser:
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
+    @pytest.mark.skipif(is_windows, reason="fails on windows")
     def test_include_dict(self):
         expected_res = {"a": 1, "b": 2, "c": 3, "d": 4}
         with tempfile.NamedTemporaryFile("w") as fdin:
@@ -1336,6 +1339,7 @@ class TestConfigParser:
             )
             assert config3["a"] == expected_res
 
+    @pytest.mark.skipif(is_windows, reason="fails on windows")
     def test_include_substitution(self):
         with tempfile.NamedTemporaryFile("w") as fdin:
             fdin.write("y = ${x}")

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3,6 +3,7 @@ import tempfile
 import pytest
 
 from pyhocon import ConfigFactory
+from pyhocon.compat import is_windows
 from pyhocon.converter import HOCONConverter
 
 
@@ -178,6 +179,7 @@ class TestHOCONConverter(object):
                         line.strip() for line in converted.split("\n") if line.strip()
                     ]
 
+    @pytest.mark.skipif(is_windows, reason="fails on windows")
     def test_convert_from_file(self):
         self._test_convert_from_file(
             TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_JSON, "json"


### PR DESCRIPTION
skipped 4 tests on windows

```
================================== FAILURES ===================================
_____________________ TestConfigParser.test_include_file ______________________

self = <test_config_parser.TestConfigParser object at 0x00000189D173AAD0>

    def test_include_file(self):
        with tempfile.NamedTemporaryFile("w") as fdin:
            fdin.write("[1, 2]")
            fdin.flush()
    
            config1 = ConfigFactory.parse_string(
                """
                a: [
                    include "{tmp_file}"
                ]
                """.format(
                    tmp_file=fdin.name
                )
            )
>           assert config1["a"] == [1, 2]
E           assert [] == [1, 2]
E             Right contains 2 more items, first extra item: 1
E             Full diff:
E             - [1, 2]
E             + []

tests\test_config_parser.py:1187: AssertionError
------------------------------ Captured log call ------------------------------
WARNING  pyhocon.config_parser:config_parser.py:161 Cannot include file C:\Users\RUNNER~1\AppData\Local\Temp	mpu6e6kwl8. File does not exist or cannot be read.
_____________________ TestConfigParser.test_include_dict ______________________

self = <test_config_parser.TestConfigParser object at 0x00000189D173A560>

    def test_include_dict(self):
        expected_res = {"a": 1, "b": 2, "c": 3, "d": 4}
        with tempfile.NamedTemporaryFile("w") as fdin:
            fdin.write("{a: 1, b: 2}")
            fdin.flush()
    
            config1 = ConfigFactory.parse_string(
                """
                a: {{
                    include "{tmp_file}"
                    c: 3
                    d: 4
                }}
                """.format(
                    tmp_file=fdin.name
                )
            )
>           assert config1["a"] == expected_res
E           AssertionError: assert ConfigTree([(...3), ('d', 4)]) == {'a': 1, 'b':...c': 3, 'd': 4}
E             Omitting 2 identical items, use -vv to show
E             Right contains 2 more items:
E             {'a': 1, 'b': 2}
E             Full diff:
E             - {'a': 1, 'b': 2, 'c': 3, 'd': 4}
E             + ConfigTree([('c', 3), ('d', 4)])

tests\test_config_parser.py:1311: AssertionError
------------------------------ Captured log call ------------------------------
WARNING  pyhocon.config_parser:config_parser.py:161 Cannot include file C:\Users\RUNNER~1\AppData\Local\Temp	mpzc78klpk. File does not exist or cannot be read.
_________________ TestConfigParser.test_include_substitution __________________

self = <test_config_parser.TestConfigParser object at 0x00000189D173A440>

    def test_include_substitution(self):
        with tempfile.NamedTemporaryFile("w") as fdin:
            fdin.write("y = ${x}")
            fdin.flush()
    
            config = ConfigFactory.parse_string(
                """
                include "{tmp_file}"
                x = 42
                """.format(
                    tmp_file=fdin.name
                )
            )
            assert config["x"] == 42
>           assert config["y"] == 42

tests\test_config_parser.py:1353: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\config_tree.py:4[25](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:26): in __getitem__
    val = self.get(item)
C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\config_tree.py:[26](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:27)1: in get
    return self._get(ConfigTree.parse_key(key), 0, default)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = ConfigTree([('x', 42)]), key_path = ['y'], key_index = 0
default = <class 'pyhocon.config_tree.UndefinedKey'>

    def _get(self, key_path, key_index=0, default=UndefinedKey):
        key_elt = key_path[key_index]
        elt = super().get(key_elt, UndefinedKey)
    
        if elt is UndefinedKey:
            if default is UndefinedKey:
>               raise ConfigMissingException(
                    "No configuration setting found for key {key}".format(
                        key=".".join(key_path[: key_index + 1])
                    )
                )
E               pyhocon.exceptions.ConfigMissingException: 'No configuration setting found for key y'

C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\config_tree.py:194: ConfigMissingException
------------------------------ Captured log call ------------------------------
WARNING  pyhocon.config_parser:config_parser.py:161 Cannot include file C:\Users\RUNNER~1\AppData\Local\Temp	mpw3i5u3z1. File does not exist or cannot be read.
__________________ TestHOCONConverter.test_convert_from_file __________________

self = <test_tool.TestHOCONConverter object at 0x00000189D1AF0250>

    def test_convert_from_file(self):
>       self._test_convert_from_file(
            TestHOCONConverter.CONFIG_STRING, TestHOCONConverter.EXPECTED_JSON, "json"
        )

tests\test_tool.py:182: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests\test_tool.py:170: in _test_convert_from_file
    HOCONConverter.convert_from_file(fdin.name, fdout.name, format)
C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\converter.py:[31](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:32)7: in convert_from_file
    config = ConfigFactory.parse_file(input_file)
C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\config_parser.py:160: in parse_file
    raise e
C:\hostedtoolcache\windows\Python\3.10.8\x64\lib\site-packages\pyhocon\config_parser.py:1[53](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:54): in parse_file
    with codecs.open(filename, "r", encoding=encoding) as fd:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

filename = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp88di1uj5', mode = 'rb'
encoding = 'utf-8', errors = 'strict', buffering = -1

    def open(filename, mode='r', encoding=None, errors='strict', buffering=-1):
    
        """ Open an encoded file using the given mode and return
            a wrapped version providing transparent encoding/decoding.
    
            Note: The wrapped version will only accept the object format
            defined by the codecs, i.e. Unicode objects for most builtin
            codecs. Output is also codec dependent and will usually be
            Unicode as well.
    
            Underlying encoded files are always opened in binary mode.
            The default file mode is 'r', meaning to open the file in read mode.
    
            encoding specifies the encoding which is to be used for the
            file.
    
            errors may be given to define the error handling. It defaults
            to 'strict' which causes ValueErrors to be raised in case an
            encoding error occurs.
    
            buffering has the same meaning as for the builtin open() API.
            It defaults to -1 which means that the default buffer size will
            be used.
    
            The returned wrapped file object provides an extra attribute
            .encoding which allows querying the used encoding. This
            attribute is only available if an encoding was specified as
            parameter.
    
        """
        if encoding is not None and \
           'b' not in mode:
            # Force opening of the file in binary mode
            mode = mode + 'b'
>       file = builtins.open(filename, mode, buffering)
E       PermissionError: [Errno 13] Permission denied: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp88di1uj5'

C:\hostedtoolcache\windows\Python\3.10.8\x[64](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:65)\lib\codecs.py:[90](https://github.com/fangchenli/pyhocon3/actions/runs/3611179382/jobs/6085491869#step:5:91)5: PermissionError
```